### PR TITLE
don't gamepad poll when profile null to avoid endless throw catch

### DIFF
--- a/Master/NucleusGaming/New/PositionsControl.cs
+++ b/Master/NucleusGaming/New/PositionsControl.cs
@@ -298,6 +298,10 @@ namespace Nucleus.Coop
 
         private void GamepadPollTimer_Tick(object state)/* object sender, EventArgs e)*/
         {
+            if (profile == null)
+            {
+                return;
+            }
             gamePadPressed = -1;
             try
             {


### PR DESCRIPTION
Right now, this function tries to run even when profile is null, which leads to an exception that is immediately caught. This makes debugging the program frustrating, and requires filtering out the exception.

I check if profile is null and return early.