### PR TITLE
Created Meta Issue Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,7 +1,7 @@
 name: "🌐 Meta Issue"
 description: Addressing an issue at the repository / project-wide level
 title: '🌐 <meta issue name>'
-labels: [🌐 Meta Issue]
+labels: [🌐 meta mssue]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,7 +1,7 @@
 name: "📇 Meta/Repository Issue" Meta/Repository
 description: Address an issue at the repository / project-wide level
 title: '📇 <meta issue name>'
-labels: [📇 meta/repository issue]
+labels: [📇 meta issue]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,7 +1,7 @@
-name: "📇 Meta/Repository Issue" Meta/Repository
+name: "📇 Meta/Repository Issue"
 description: Address an issue at the repository / project-wide level
 title: '📇 <meta issue name>'
-labels: [📇 meta issue]
+labels: [📇 meta/repository issue]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,0 +1,35 @@
+name: "🌐 Meta Issue"
+description: Addressing an issue at the repository / project-wide level
+title: '🌐 <feature name>'
+labels: [🌐 Meta Issue]
+body:
+  - type: markdown
+    attributes:
+      value: "## Before you continue, please search our open/closed issues to see if a similar issue has been addressed."
+
+  - type: checkboxes
+    attributes:
+      label: I have searched through the issues and didn't find my problem.
+      options:
+        - label: Confirm
+          required: true
+
+  - type: textarea
+    id: currentproblem
+    attributes:
+      label: Problem
+      description: Tell us about the meta-level issue you would like to address. Feel free to show examples where, why and how it might be useful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: possiblesolution
+    attributes:
+      label: Possible Solution
+      description: If you have an idea, please tell us how this feature can be implemented.
+
+  - type: textarea
+    id: extrainformation
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this feature request?

--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,6 +1,6 @@
 name: "🌐 Meta Issue"
 description: Addressing an issue at the repository / project-wide level
-title: '🌐 <feature name>'
+title: '🌐 <meta issue name>'
 labels: [🌐 Meta Issue]
 body:
   - type: markdown
@@ -15,21 +15,20 @@ body:
           required: true
 
   - type: textarea
-    id: currentproblem
+    id: currentissue
     attributes:
-      label: Problem
-      description: Tell us about the meta-level issue you would like to address. Feel free to show examples where, why and how it might be useful.
+      label: Issue
+      description: Tell us about the issue you would like to address. Feel free to show examples where, why and how addressing this issue might be useful.
     validations:
       required: true
 
   - type: textarea
-    id: possiblesolution
+    id: suggestedchange
     attributes:
-      label: Possible Solution
-      description: If you have an idea, please tell us how this feature can be implemented.
-
+      label: Suggested Change
+      description: Please suggest any changes that you think could resolve the issue. The more specific, the better!
   - type: textarea
     id: extrainformation
     attributes:
       label: Additional information
-      description: Is there anything else we should know about this feature request?
+      description: Is there anything else we should know, or anything else you would like to add?

--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,7 +1,7 @@
-name: "🌐 Meta Issue"
-description: Addressing an issue at the repository / project-wide level
-title: '🌐 <meta issue name>'
-labels: [🌐 meta mssue]
+name: "📇 Meta/Repository Issue" Meta/Repository
+description: Address an issue at the repository / project-wide level
+title: '📇 <meta issue name>'
+labels: [📇 meta/repository issue]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/meta_app.yml
+++ b/.github/ISSUE_TEMPLATE/meta_app.yml
@@ -1,7 +1,7 @@
 name: "📇 Meta/Repository Issue"
 description: Address an issue at the repository / project-wide level
 title: '📇 <meta issue name>'
-labels: [📇 meta/repository issue]
+labels: [📇 Meta/Repository]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Hello!

I created a new Meta/Repository issue form to address[ issue #26](https://github.com/SplitScreen-Me/splitscreenme-nucleus/issues/26). I used the existing 'new feature' form as the template, to try and keep design/phrasing consistent with the other forms.

I *think* I got the label to where it matches the existing Meta/Repo label tag + emoji. It appeared to automatically label the issue in the most recent test on my fork, (and I copy/pasted the label text from here, so it *should* be a match). That said, this is my first crack at that sort of thing, so hopefully it works as intended. I debated adding a bug log to the form, but wasn't sure if it was necessary or not (though it might be handy for browser issues maybe?) - I can add it back in if necessary.

Let me know if there's anything that I need to tweak or change! Thanks!