### PR TITLE
ProtoInput new options

### DIFF
--- a/Master/NucleusGaming/Coop/ProtoInput/ProtoInput.cs
+++ b/Master/NucleusGaming/Coop/ProtoInput/ProtoInput.cs
@@ -29,6 +29,9 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             public uint FindWindowHookID = (uint)ProtoHookIDs.FindWindowHookID;
             public uint CreateSingleHIDHookID = (uint)ProtoHookIDs.CreateSingleHIDHookID;
             public uint WindowStyleHookID = (uint)ProtoHookIDs.WindowStyleHookID;
+            public uint MoveWindowHookID = (uint)ProtoHookIDs.MoveWindowHookID;
+            public uint AdjustWindowRectHookID = (uint)ProtoHookIDs.AdjustWindowRectHookID;
+            public uint RemoveBorderHookID = (uint)ProtoHookIDs.RemoveBorderHookID;
 
             public uint RawInputFilterID = (uint)ProtoMessageFilterIDs.RawInputFilterID;
             public uint MouseMoveFilterID = (uint)ProtoMessageFilterIDs.MouseMoveFilterID;
@@ -62,7 +65,10 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             BlockRawInputHookID,
             FindWindowHookID,
             CreateSingleHIDHookID,
-            WindowStyleHookID
+            WindowStyleHookID,
+            MoveWindowHookID,
+            AdjustWindowRectHookID,
+            RemoveBorderHookID
         };
 
         public enum ProtoMessageFilterIDs : uint
@@ -123,7 +129,8 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                     bool sendMouseWheelMessages,
                                     bool sendMouseButtonMessages,
                                     bool sendMouseMoveMessages,
-                                    bool sendKeyboardPressMessages);
+                                    bool sendKeyboardPressMessages,
+                                    bool sendMouseDblClkMessages);
 
             [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void StartFocusMessageLoop(uint instanceHandle, int milliseconds,
@@ -157,6 +164,19 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void SetShowCursorWhenImageUpdated(uint instanceHandle, bool enable);
 
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetPutMouseInsideWindow(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetDefaultTopLeftMouseBounds(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetDefaultBottomRightMouseBounds(uint instanceHandle, bool enable);
+
+            // This MUST be called before calling InstallHook on the RemoveBorderhook
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetDontWaitWindowBorder(uint instanceHandle, bool enable);
+
             // Both of these functions require RenameHandlesHookHookID hook
             [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void AddHandleToRename(uint instanceHandle, string name);
@@ -183,6 +203,12 @@ namespace Nucleus.Gaming.Coop.ProtoInput
 
             [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void SetSetWindowPosSettings(uint instanceHandle, int posx, int posy, int width, int height);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetSetWindowPosDontResize(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetSetWindowPosDontReposition(uint instanceHandle, bool enable);
 
             [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void SetCreateSingleHIDName(uint instanceHandle, string name);
@@ -213,6 +239,18 @@ namespace Nucleus.Gaming.Coop.ProtoInput
 
             [DllImport("ProtoInputUtilDynamic32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void GetTaskbarVisibility(out bool autoHide, out bool alwaysOnTop);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetMoveWindowSettings(uint instanceHandle, int posx, int posy, int width, int height);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetMoveWindowDontResize(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetMoveWindowDontReposition(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader32.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetAdjustWindowRectSettings(uint instanceHandle, int posx, int posy, int width, int height);
         }
 
         private static class ProtoInput64
@@ -261,7 +299,8 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                     bool sendMouseWheelMessages,
                                     bool sendMouseButtonMessages,
                                     bool sendMouseMoveMessages,
-                                    bool sendKeyboardPressMessages);
+                                    bool sendKeyboardPressMessages,
+                                    bool sendMouseDblClkMessages);
 
             [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void StartFocusMessageLoop(uint instanceHandle, int milliseconds,
@@ -320,6 +359,12 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             public static extern void SetSetWindowPosSettings(uint instanceHandle, int posx, int posy, int width, int height);
 
             [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetSetWindowPosDontResize(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetSetWindowPosDontReposition(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void SetCreateSingleHIDName(uint instanceHandle, string name);
 
             [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
@@ -337,6 +382,19 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void SetShowCursorWhenImageUpdated(uint instanceHandle, bool enable);
 
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetPutMouseInsideWindow(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetDefaultTopLeftMouseBounds(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetDefaultBottomRightMouseBounds(uint instanceHandle, bool enable);
+
+            // This MUST be called before calling InstallHook on the RemoveBorderhook
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetDontWaitWindowBorder(uint instanceHandle, bool enable);
+
             [DllImport("ProtoInputUtilDynamic64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern uint LockInput(bool lockInput);
 
@@ -351,6 +409,18 @@ namespace Nucleus.Gaming.Coop.ProtoInput
 
             [DllImport("ProtoInputUtilDynamic64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
             public static extern void GetTaskbarVisibility(out bool autoHide, out bool alwaysOnTop);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetMoveWindowSettings(uint instanceHandle, int posx, int posy, int width, int height);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetMoveWindowDontResize(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetMoveWindowDontReposition(uint instanceHandle, bool enable);
+
+            [DllImport("ProtoInputLoader64.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void SetAdjustWindowRectSettings(uint instanceHandle, int posx, int posy, int width, int height);
         }
 
         public uint LockInput(bool lockInput)
@@ -569,7 +639,8 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                     bool sendMouseWheelMessages,
                                     bool sendMouseButtonMessages,
                                     bool sendMouseMoveMessages,
-                                    bool sendKeyboardPressMessages)
+                                    bool sendKeyboardPressMessages,
+                                    bool sendMouseDblClkMessages)
         {
             if (IntPtr.Size == 4)
             {
@@ -577,7 +648,8 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                     sendMouseWheelMessages,
                                     sendMouseButtonMessages,
                                     sendMouseMoveMessages,
-                                    sendKeyboardPressMessages);
+                                    sendKeyboardPressMessages,
+                                    sendMouseDblClkMessages);
             }
             else
             {
@@ -585,7 +657,8 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                     sendMouseWheelMessages,
                                     sendMouseButtonMessages,
                                     sendMouseMoveMessages,
-                                    sendKeyboardPressMessages);
+                                    sendKeyboardPressMessages,
+                                    sendMouseDblClkMessages);
             }
         }
 
@@ -717,6 +790,54 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             }
         }
 
+        public void SetPutMouseInsideWindow(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetPutMouseInsideWindow(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetPutMouseInsideWindow(instanceHandle, enable);
+            }
+        }
+
+        public void SetDefaultTopLeftMouseBounds(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetDefaultTopLeftMouseBounds(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetDefaultTopLeftMouseBounds(instanceHandle, enable);
+            }
+        }
+
+        public void SetDefaultBottomRightMouseBounds(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetDefaultBottomRightMouseBounds(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetDefaultBottomRightMouseBounds(instanceHandle, enable);
+            }
+        }
+
+        public void SetDontWaitWindowBorder(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetDontWaitWindowBorder(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetDontWaitWindowBorder(instanceHandle, enable);
+            }
+        }
+
         /// <summary>
         /// Require RenameHandlesHookHookID hook
         /// </summary>
@@ -831,6 +952,30 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             }
         }
 
+        public void SetSetWindowPosDontResize(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetSetWindowPosDontResize(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetSetWindowPosDontResize(instanceHandle, enable);
+            }
+        }
+
+        public void SetSetWindowPosDontReposition(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetSetWindowPosDontReposition(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetSetWindowPosDontReposition(instanceHandle, enable);
+            }
+        }
+
         public void SetCreateSingleHIDName(uint instanceHandle, string name)
         {
             if (IntPtr.Size == 4)
@@ -918,5 +1063,54 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                 ProtoInput64.SetTaskbarVisibility(autohide, false);
             }
         }
+
+        public void SetMoveWindowSettings(uint instanceHandle, int posx, int posy, int width, int height)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetMoveWindowSettings(instanceHandle, posx, posy, width, height);
+            }
+            else
+            {
+                ProtoInput64.SetMoveWindowSettings(instanceHandle, posx, posy, width, height);
+            }
+        }
+
+        public void SetMoveWindowDontResize(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetMoveWindowDontResize(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetMoveWindowDontResize(instanceHandle, enable);
+            }
+        }
+
+        public void SetMoveWindowDontReposition(uint instanceHandle, bool enable)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetMoveWindowDontReposition(instanceHandle, enable);
+            }
+            else
+            {
+                ProtoInput64.SetMoveWindowDontReposition(instanceHandle, enable);
+            }
+        }
+
+        public void SetAdjustWindowRectSettings(uint instanceHandle, int posx, int posy, int width, int height)
+        {
+            if (IntPtr.Size == 4)
+            {
+                ProtoInput32.SetAdjustWindowRectSettings(instanceHandle, posx, posy, width, height);
+            }
+            else
+            {
+                ProtoInput64.SetAdjustWindowRectSettings(instanceHandle, posx, posy, width, height);
+            }
+        }
+
     }
 }

--- a/Master/NucleusGaming/Coop/ProtoInput/ProtoInputEnumsOptions.cs
+++ b/Master/NucleusGaming/Coop/ProtoInput/ProtoInputEnumsOptions.cs
@@ -1,0 +1,35 @@
+﻿namespace Nucleus.Gaming
+{
+    public enum SetWindowPosHook
+    {
+        True = 1,
+        DontResize,
+        DontReposition
+    }
+
+    public enum MoveWindowHook
+    {
+        True = 1,
+        DontResize,
+        DontReposition
+    }
+
+    public enum DrawFakeCursor
+    {
+        True = 1,
+        Fix
+    }
+
+    public enum PutMouseInsideWindow
+    {
+        True = 1,
+        IgnoreTopLeft,
+        IgnoreBottomRight
+    }
+
+    public enum SetRemoveBorderHook
+    {
+        True = 1,
+        DontWait
+    }
+}

--- a/Master/NucleusGaming/Coop/ProtoInput/ProtoInputLauncher.cs
+++ b/Master/NucleusGaming/Coop/ProtoInput/ProtoInputLauncher.cs
@@ -210,8 +210,10 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                 ProtoInput.protoInput.InstallHook(instanceHandle, ProtoInput.ProtoHookIDs.DinputOrderHookID);
             }
 
+            ProtoInput.protoInput.SetSetWindowPosDontResize(instanceHandle, gen.ProtoInput.SetWindowPosHook == SetWindowPosHook.DontResize);
+            ProtoInput.protoInput.SetSetWindowPosDontReposition(instanceHandle, gen.ProtoInput.SetWindowPosHook == SetWindowPosHook.DontReposition);
             ProtoInput.protoInput.SetSetWindowPosSettings(instanceHandle, player.MonitorBounds.X, player.MonitorBounds.Y, player.MonitorBounds.Width, player.MonitorBounds.Height);
-            if (gen.ProtoInput.SetWindowPosHook)
+            if (gen.ProtoInput.SetWindowPosHook == SetWindowPosHook.DontResize || gen.ProtoInput.SetWindowPosHook == SetWindowPosHook.DontReposition || gen.ProtoInput.SetWindowPosHook != 0)
             {
                 ProtoInput.protoInput.InstallHook(instanceHandle, ProtoInput.ProtoHookIDs.SetWindowPosHookID);
             }
@@ -256,6 +258,26 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                 ProtoInput.protoInput.EnableMessageFilter(instanceHandle, ProtoInput.ProtoMessageFilterIDs.KeyboardButtonFilterID);
             }
 
+            ProtoInput.protoInput.SetMoveWindowDontResize(instanceHandle, gen.ProtoInput.MoveWindowHook == MoveWindowHook.DontResize);
+            ProtoInput.protoInput.SetMoveWindowDontReposition(instanceHandle, gen.ProtoInput.MoveWindowHook == MoveWindowHook.DontReposition);
+            ProtoInput.protoInput.SetMoveWindowSettings(instanceHandle, player.MonitorBounds.X, player.MonitorBounds.Y, player.MonitorBounds.Width, player.MonitorBounds.Height);
+            if (gen.ProtoInput.MoveWindowHook == MoveWindowHook.DontResize || gen.ProtoInput.MoveWindowHook == MoveWindowHook.DontReposition || gen.ProtoInput.MoveWindowHook != 0)
+            {
+                ProtoInput.protoInput.InstallHook(instanceHandle, ProtoInput.ProtoHookIDs.MoveWindowHookID);
+            }
+
+            ProtoInput.protoInput.SetAdjustWindowRectSettings(instanceHandle, player.MonitorBounds.X, player.MonitorBounds.Y, player.MonitorBounds.Width, player.MonitorBounds.Height);
+            if (gen.ProtoInput.AdjustWindowRectHook)
+            {
+                ProtoInput.protoInput.InstallHook(instanceHandle, ProtoInput.ProtoHookIDs.AdjustWindowRectHookID);
+            }
+
+            ProtoInput.protoInput.SetDontWaitWindowBorder(instanceHandle, gen.ProtoInput.SetRemoveBorderHook == SetRemoveBorderHook.DontWait);
+            if (gen.ProtoInput.SetRemoveBorderHook == SetRemoveBorderHook.DontWait || gen.ProtoInput.SetRemoveBorderHook != 0)
+            {
+                ProtoInput.protoInput.InstallHook(instanceHandle, ProtoInput.ProtoHookIDs.RemoveBorderHookID);
+            }
+
             if (gen.ProtoInput.BlockedMessages != null)
             {
                 foreach (uint blockedMessage in gen.ProtoInput.BlockedMessages)
@@ -268,7 +290,8 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                 gen.ProtoInput.SendMouseWheelMessages,
                                 gen.ProtoInput.SendMouseButtonMessages,
                                 gen.ProtoInput.SendMouseMovementMessages,
-                                gen.ProtoInput.SendKeyboardButtonMessages);
+                                gen.ProtoInput.SendKeyboardButtonMessages,
+                                gen.ProtoInput.SendMouseDblClkMessages);
 
             if (gen.ProtoInput.EnableFocusMessageLoop)
             {
@@ -282,6 +305,9 @@ namespace Nucleus.Gaming.Coop.ProtoInput
             }
 
             ProtoInput.protoInput.SetDrawFakeCursor(instanceHandle, gen.ProtoInput.DrawFakeCursor);
+            ProtoInput.protoInput.SetDefaultTopLeftMouseBounds(instanceHandle, gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreTopLeft);
+            ProtoInput.protoInput.SetDefaultBottomRightMouseBounds(instanceHandle, gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreBottomRight);
+            ProtoInput.protoInput.SetPutMouseInsideWindow(instanceHandle, gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreTopLeft || gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreBottomRight || gen.ProtoInput.PutMouseInsideWindow != 0);
             ProtoInput.protoInput.AllowFakeCursorOutOfBounds(instanceHandle, gen.ProtoInput.AllowFakeCursorOutOfBounds, gen.ProtoInput.ExtendFakeCursorBounds);
             ProtoInput.protoInput.SetToggleFakeCursorVisibilityShortcut(instanceHandle,
                 gen.ProtoInput.EnableToggleFakeCursorVisibilityShortcut,

--- a/Master/NucleusGaming/Coop/ProtoInput/ProtoInputOptions.cs
+++ b/Master/NucleusGaming/Coop/ProtoInput/ProtoInputOptions.cs
@@ -24,11 +24,14 @@ namespace Nucleus.Gaming.Coop.ProtoInput
         public bool RenameHandlesHook;
         public bool XinputHook;
         public bool DinputDeviceHook;
-        public bool SetWindowPosHook;
+        public SetWindowPosHook SetWindowPosHook;
         public bool BlockRawInputHook;
         public bool FindWindowHook;
         public bool CreateSingleHIDHook;
         public bool SetWindowStyleHook;
+        public MoveWindowHook MoveWindowHook;
+        public bool AdjustWindowRectHook;
+        public SetRemoveBorderHook SetRemoveBorderHook;
 
         public bool RawInputFilter;
         public bool MouseMoveFilter;
@@ -48,6 +51,7 @@ namespace Nucleus.Gaming.Coop.ProtoInput
         public bool SendMouseButtonMessages;
         public bool SendMouseMovementMessages;
         public bool SendKeyboardButtonMessages;
+        public bool SendMouseDblClkMessages;
 
         public bool EnableFocusMessageLoop;
         public int FocusLoopIntervalMilliseconds = 5;
@@ -63,6 +67,7 @@ namespace Nucleus.Gaming.Coop.ProtoInput
         public bool EnableToggleFakeCursorVisibilityShortcut;
         public uint ToggleFakeCursorVisibilityShortcutVkey = 0x24; // VK_HOME
         public bool DontShowCursorWhenImageUpdated;
+        public PutMouseInsideWindow PutMouseInsideWindow;
 
         public bool UseDinputRedirection;
 

--- a/Master/NucleusGaming/Nucleus.Gaming.csproj
+++ b/Master/NucleusGaming/Nucleus.Gaming.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Coop\InputManagement\VirtualInputs.cs" />
     <Compile Include="Coop\ProfilePlayer.cs" />
     <Compile Include="Coop\GameMetaInfo.cs" />
+    <Compile Include="Coop\ProtoInput\ProtoInputEnumsOptions.cs" />
     <Compile Include="DPI\ThreadDPIContext.cs" />
     <Compile Include="Forms\NucleusMessageBox\CustomMessageBox.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
Added more hooks related to window adjustment and mouse functionality improvement.

These hooks and improvements can be used in the js handler file using these options forms:
- `Game.ProtoInput.SetWindowPosHook = true;` : `true` is the default option, `Nucleus.SetWindowPosHook.DontResize` or `Nucleus.SetWindowPosHook.DontReposition`

- `Game.ProtoInput.MoveWindowHook = true;` some games use it to set the size and the position of the window instead of SetWindowPos : `true` is the default option, `Nucleus.MoveWindowHook.DontResize` or `Nucleus.MoveWindowHook.DontReposition`

- `Game.ProtoInput.AdjustWindowRectHook = true;` mostly it needs `Game.ProtoInput.InjectStartup = true;` to be effective.

- `Game.ProtoInput.SetRemoveBorderHook = true;` will remove the border whenever it finds it and maintain the window aspect : `true` is the default option or `Nucleus.SetRemoveBorderHook.DontWait` to force the hook even if the window is borderless

- `Game.ProtoInput.SendMouseDblClkMessages = true;` enables double click messages, mostly supported in RTS games.

- `Game.ProtoInput.PutMouseInsideWindow = true;` workaround fix for scrolling the edge : `true` is the default option, `Nucleus.PutMouseInsideWindow.IgnoreTopLeft` or `Nucleus.PutMouseInsideWindow.IgnoreBottomRight`