### PR TITLE
Change DrawFakeCursor boolean to enum

### DIFF
--- a/Master/NucleusGaming/Coop/ProtoInput/ProtoInputLauncher.cs
+++ b/Master/NucleusGaming/Coop/ProtoInput/ProtoInputLauncher.cs
@@ -304,14 +304,11 @@ namespace Nucleus.Gaming.Coop.ProtoInput
                                       gen.ProtoInput.FocusLoop_WM_MOUSEACTIVATE);
             }
 
-            ProtoInput.protoInput.SetDrawFakeCursor(instanceHandle, gen.ProtoInput.DrawFakeCursor);
-
+            ProtoInput.protoInput.SetDrawFakeCursorFix(instanceHandle, gen.ProtoInput.DrawFakeCursor == DrawFakeCursor.Fix);
+            ProtoInput.protoInput.SetDrawFakeCursor(instanceHandle, gen.ProtoInput.DrawFakeCursor == DrawFakeCursor.Fix || gen.ProtoInput.DrawFakeCursor != 0);
             ProtoInput.protoInput.SetDefaultTopLeftMouseBounds(instanceHandle, gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreTopLeft);
             ProtoInput.protoInput.SetDefaultBottomRightMouseBounds(instanceHandle, gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreBottomRight);
             ProtoInput.protoInput.SetPutMouseInsideWindow(instanceHandle, gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreTopLeft || gen.ProtoInput.PutMouseInsideWindow == PutMouseInsideWindow.IgnoreBottomRight || gen.ProtoInput.PutMouseInsideWindow != 0);
-
-            ProtoInput.protoInput.SetDrawFakeCursorFix(instanceHandle, gen.ProtoInput.DrawFakeCursorFix);
-
             ProtoInput.protoInput.AllowFakeCursorOutOfBounds(instanceHandle, gen.ProtoInput.AllowFakeCursorOutOfBounds, gen.ProtoInput.ExtendFakeCursorBounds);
             ProtoInput.protoInput.SetToggleFakeCursorVisibilityShortcut(instanceHandle,
                 gen.ProtoInput.EnableToggleFakeCursorVisibilityShortcut,

--- a/Master/NucleusGaming/Coop/ProtoInput/ProtoInputOptions.cs
+++ b/Master/NucleusGaming/Coop/ProtoInput/ProtoInputOptions.cs
@@ -61,8 +61,7 @@ namespace Nucleus.Gaming.Coop.ProtoInput
         public bool FocusLoop_WM_SETFOCUS;
         public bool FocusLoop_WM_MOUSEACTIVATE;
 
-        public bool DrawFakeCursor;
-        public bool DrawFakeCursorFix;
+        public DrawFakeCursor DrawFakeCursor;
         public bool AllowFakeCursorOutOfBounds;
         public bool ExtendFakeCursorBounds;
         public bool EnableToggleFakeCursorVisibilityShortcut;


### PR DESCRIPTION
Added option for cursor draw logic.

option form:

`Game.ProtoInput.DrawFakeCursor = true;` : `true` is the default option or `Nucleus.DrawFakeCursor.Fix` to apply the new draw logic.